### PR TITLE
Fixed typo of "Why" to "We"

### DIFF
--- a/_documentation/headers.md
+++ b/_documentation/headers.md
@@ -26,7 +26,7 @@ You may have been tempted to change the statement in your code to `#include "../
 
 Why?
 
-Why have already configured CMake to instruct it which folders in our code repository it should search for in order to find our header files.  This is referred to as an *Include Path*.
+We have already configured CMake to instruct it which folders in our code repository it should search for in order to find our header files.  This is referred to as an *Include Path*.
 
 If you look at the top-level [CMakeLists.txt](https://github.com/byu-cpe/ecen330_student/blob/master/CMakeLists.txt) file, you will see lines like so:
 


### PR DESCRIPTION
It seemed obvious that the intended word here was "We", but the "Why" from the previous line was accidentally copied here instead.