### PR TITLE
Spelling fix and Clarification

### DIFF
--- a/_labs/hello_world.md
+++ b/_labs/hello_world.md
@@ -32,7 +32,7 @@ You will then modify the program to draw some graphics on the LCD screen as show
 
 Complete [Setup Step #1]({% link _setup/step_1.md %}) and [Setup Step #2]({% link _setup/step_2.md %}), linked to on the left-hand pane.  This will take some time, so start early.
 
-<ins>**Follow all steps carefully.  Make sure everything if working before proceeding.  If you get stuck during a setup step, DO NOT SKIP IT.  Ask for help on Piazza**</ins>.
+<ins>**Follow all steps carefully.  Make sure everything is working before proceeding.  If you get stuck during a setup step, DO NOT SKIP IT.  Ask for help on Piazza**</ins>.
 
 ### Compile and Run the Lab1 Code
 

--- a/_pages/gpio_registers.md
+++ b/_pages/gpio_registers.md
@@ -44,6 +44,8 @@ I have included an excerpt from the *xparameters.h* file that contains the neces
 #define XPAR_SLIDE_SWITCHES_IS_DUAL 0
 ```
 
+**Please note that this excerpt is only an example of what the *xparameters.h* file could contain. Your repository may likely have different values for the defined constants above. Best practice in your code would involve including *xparameters.h* and using the constants that are defined there.**
+
 For this lab, you only need to know the base address for the push buttons (*XPAR_PUSH_BUTTONS_BASEADDR*) and the slide switches (*XPAR_SLIDE_SWITCHES_BASEADDR*). You can ignore all of the other lines with #define. 
 
 Review the page about [header files]({% link _documentation/headers.md %}).  **Do not copy the code from xparameters.h into your C files. Follow the instructions about including header files and use the symbolic constant!**


### PR DESCRIPTION
I just fixed a word with a slight misspelling in Lab 1, and then I also added a bolded comment below the excerpt from xparameters.h in the gpio_registers.md page to clarify that the values students should actually be using in their code.